### PR TITLE
fixed border gap of WizardStep in Chrome zoomed

### DIFF
--- a/src/assets/form-wizard/_wizard-card.scss
+++ b/src/assets/form-wizard/_wizard-card.scss
@@ -41,9 +41,14 @@
       display: flex;
       justify-content: center;
       flex: 1;
-      border-radius: 40%;
-      &.square_shape, &.tab_shape {
+      border-radius: 50%;
+      margin: -3px;
+      &.square_shape {
         border-radius: 0;
+      }
+      &.tab_shape {
+        border-radius: 0;
+        margin: 0;
       }
     }
     .wizard-icon {


### PR DESCRIPTION
In Chrome, zoom in or out by some magnification, there are small gaps between border and inner container at checked step.
I fill it.
![border_gap](https://user-images.githubusercontent.com/7163720/48659385-7a6f3280-ea93-11e8-909e-a55fb8fa85df.jpg)
