### PR TITLE
Feature/allow nested tab components

### DIFF
--- a/src/components/FormWizard.vue
+++ b/src/components/FormWizard.vue
@@ -235,9 +235,10 @@
         this.$emit('update:startIndex', nextIndex)
       },
       addTab (item) {
-        const index = this.$slots.default.indexOf(item.$vnode)
+        const index = this.tabs.length
         item.tabId = `${item.title.replace(/ /g, '')}${index}`
-        this.tabs.splice(index, 0, item)
+        this.tabs.push(item)
+
         // if a step is added before the current one, go to it
         if (index < this.activeTabIndex + 1) {
           this.maxStep = index

--- a/src/components/TabContent.vue
+++ b/src/components/TabContent.vue
@@ -65,7 +65,7 @@
         return this.$parent.errorColor
       }
     },
-    mounted () {
+    created () {
       this.addTab(this)
     },
     destroyed () {

--- a/test/unit/specs/FormWizard.spec.js
+++ b/test/unit/specs/FormWizard.spec.js
@@ -129,6 +129,9 @@ describe('FormWizard.vue', () => {
       Vue.nextTick(() => {
         const tabs = wizard.findAll(WizardTab)
         expect(tabs.length).to.equal(3)
+        expect(wizard.vm.tabs[0].title).to.equal('Personal details')
+        expect(wizard.vm.tabs[1].title).to.equal('Additional Info')
+        expect(wizard.vm.tabs[2].title).to.equal('Last step')
         done()
       })
     })

--- a/test/unit/specs/FormWizard.spec.js
+++ b/test/unit/specs/FormWizard.spec.js
@@ -20,7 +20,6 @@ const router = new VueRouter({
   ]
 })
 
-
 const startIndex = 0
 let validationMethod = sinon.stub()
 validationMethod.returns(true)
@@ -407,7 +406,7 @@ describe('FormWizard.vue', () => {
               </tab-content>
           </form-wizard>`,
         methods: {
-          validationMethod,
+          validationMethod
         }
       }
     })
@@ -428,14 +427,14 @@ describe('FormWizard.vue', () => {
       wizardInstance.vm.nextTab()
       wizardInstance.vm.prevTab()
       expect(threeStepWizard.methods.validationMethod.should.have.been.called)
-    }) 
+    })
   })
-  describe('with vue-router', ()=> {
+  describe('with vue-router', () => {
     it('renders correct tab contents', () => {
       const wizard = mount(routerWizard, {localVue, router})
       const wizardInstance = wizard.find(FormWizard)
       let tabs = wizardInstance.findAll(WizardTab)
-      let firstTab  = tabs.at(0)
+      let firstTab = tabs.at(0)
       expect(tabs.length).to.equal(3)
       expect(firstTab.vm.route).to.equal(wizardInstance.vm.$route.path)
     })
@@ -446,14 +445,12 @@ describe('FormWizard.vue', () => {
       let tabs = wizardInstance.findAll(WizardTab)
       wizardInstance.vm.activateAll()
       wizardInstance.vm.$router.push('/second')
-      Vue.nextTick(()=> {
+      Vue.nextTick(() => {
         let secondTab = tabs.at(1)
         expect(secondTab.vm.route).to.equal(wizardInstance.vm.$route.path)
         expect(secondTab.vm.active).to.equal(true)
         done()
       })
-
-
     })
   })
 })


### PR DESCRIPTION
### Bug
The order of content-tabs is broken if one or more tabs are wrapped within other tags or components. Take a look at the extended unit test. 

### Problem
Large wizards may use sub components to keep a clear structure and before-change validation. There are issues relating to this, e.g. https://github.com/BinarCode/vue-form-wizard/issues/247

### Explanation
Searching $slots für tab-contents to get an index will fail for nested components as indexOf will return -1:
```js
const index = this.$slots.default.indexOf(item.$vnode)
```

But there is even a problem with the current implementation and non-nested components. Imagine the following markup:
```html
<form-wizard>
  <content-tab title="Tab1"/>
  <content-tab title="Tab2"/>
  <content-tab title="Tab3"/>
</form-wizard>
```
Array.splice() won't work correctly as the tabs may come up in the following order:
 - Tab1 registers first with index 1-> [Tab1]
 - Tab3 follows with index 3 -> [Tab1, Tab3]
 - Tab2 follows with index 2 -> [Tab1, Tab3, Tab2]

=> The result of using splice with an index is not like desired. The order in which subcomponents are registered is still critical. 

### Solution
Using Array.push() will still be dependent of the tab registration order but fix the lookup of nested components. Furthermore, adding tabs when they are created instead of mounted may help to be more consistent.

### Further improvements
We need to come up with a solution to be independent of component registration order. This way we can also handle dynamically toggled tabs.