### PR TITLE
Add lazy-load property to `TabContent`

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -142,6 +142,13 @@ props: {
     default: ''
   },
   /***
+   * Only render the content when the tab is active
+   */
+  lazy: {
+    type: Boolean,
+    default: false
+  },
+  /***
    * Function to execute before tab switch. Return value must be boolean
    * If the return result is false, tab switch is restricted
    */

--- a/src/components/TabContent.vue
+++ b/src/components/TabContent.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-show="active" class="wizard-tab-container"
+  <div v-show="active" v-if="!lazy || active" class="wizard-tab-container"
        role="tabpanel"
        :id="tabId"
        :aria-hidden="!active"
@@ -22,6 +22,13 @@
       icon: {
         type: String,
         default: ''
+      },
+      /***
+       * Only render the content when the tab is active
+       */
+      lazy: {
+        type: Boolean,
+        default: false
       },
       /***
        * Function to execute before tab switch. Return value must be boolean


### PR DESCRIPTION
In its current state, the contents of all tabs in the wizard are rendered on first load, generating a potentially large number of DOM nodes. In a larger form, this can really add up (and [Lighthouse doesn't like it](https://developers.google.com/web/tools/lighthouse/audits/dom-size)).

This PR creates a new boolean property on `TabContent`, allowing the user to indicate that instead of `v-show`, the tab should be hidden (i.e. not rendered) with `v-if`.